### PR TITLE
A Fix for Missing Closing Paranthesis in Column List

### DIFF
--- a/GenerateInsert.sql
+++ b/GenerateInsert.sql
@@ -270,8 +270,8 @@ BEGIN
   BEGIN
     SET @ColumnList = @ColumnList
       + CASE WHEN @ColumnList != N'' THEN N',' ELSE N'' END
-      + QUOTENAME(@ColumnName)
-      + CASE WHEN @GenerateOneColumnPerLine = 1 THEN @CrLf ELSE N'' END;
+      + CASE WHEN @GenerateOneColumnPerLine = 1 AND ISNULL(@ColumnList, '') <> '' THEN @CrLf ELSE N'' END   -- Add @CrLf only if not the first column.
+      + QUOTENAME(@ColumnName);
   
     SET @SelectList = @SelectList
       + CASE WHEN @SelectList != N'' THEN N'+'',''+' + @CrLf ELSE N'' END


### PR DESCRIPTION
When I executed the SP with the following settings, it cause a syntax error because no closing parathesis was specified for column list:
EXEC dbo.GenerateInsert @ObjectName='MyTable', @GenerateOneColumnPerLine=1, @PrintGeneratedCode=1

As I delved into the code, I discovered a simple solution was adding a CrLf character BEFORE each column name and not adding it for the first column.