### PR TITLE
Added the ability to include or exclude specific columns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Generates INSERT statement(s) for data in a table.
 
 ## Change Log ##
 
+- Build 7. Added support for including or excluding columns.
 - Build 6. Added support for table-valued and inline user defined functions.
 - Build 5. Fixed an issue with strings longer than 4000 characters.
 - Build 4. New option to sort data returned by a query.


### PR DESCRIPTION
Added two parameters allowing you to include or exclude columns by name. 

Example
``` sql 
-- This ensures that ID, Name, and DateAdded are included but DateAdded, Date Changed, AddedByID, and ChangedByID are not. 
-- If a row is included in both lists, it will be excluded. 

EXECUTE dbo.GenerateInsert @ObjectName = N'dbo.MYTABLE', @ColumnExclusion = 'DATEADDED,DATECHANGED,ADDEDBYID,CHANGEDBYID', @COLUMNINCLUSION='ID,NAME,DATEADDED';

```