### PR TITLE
Fix for issue of results table not returning data in insert order

### DIFF
--- a/GenerateInsert.sql
+++ b/GenerateInsert.sql
@@ -149,7 +149,7 @@ SET @ValuesSql = N'VALUES (';
 DECLARE @SelectSql nvarchar(max);
 SET @SelectSql = N'SELECT ';
 DECLARE @TableData table (TableRow nvarchar(max));
-DECLARE @Results table (TableRow nvarchar(max));
+DECLARE @Results table (TableRow nvarchar(max),Id BIGINT IDENTITY(1,1), PRIMARY KEY (Id));
 DECLARE @TableRow nvarchar(max);
 DECLARE @RowNo int;
 
@@ -541,7 +541,7 @@ BEGIN
   CLOSE ResultsCursor;
   DEALLOCATE ResultsCursor;
 END ELSE BEGIN
-  SELECT *
+  SELECT TableRow
   FROM @Results;
 END
 


### PR DESCRIPTION
Hi, I noticed that the insert and identity on/off statements when pulling from a view often got mixed up and would appear randomly within the output.

I identified the issue being the @Results table not having a primary key therefore the results wouldn't necessarily be returned in a specific order.

By adding an IDENTITY column then setting that as the Primary Key the issue was resolved.

Thanks for sql it's been a great help :)